### PR TITLE
Update all generator API to use generator instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,20 @@ use them to generate a random name using their functionality.
 
 #### Usage
 ```php
-$generator = new \Nubs\RandomNameGenerator\All();
+$generator = \Nubs\RandomNameGenerator\All::create();
 echo $generator->getName();
+```
+
+Alternatively, if you want to configure/build the generators to use instead of
+using all of the available generators, you can construct them yourself:
+
+```php
+$generator = new \Nubs\RandomNameGenerator\All(
+    [
+        new \Nubs\RandomNameGenerator\Alliteration(),
+        new \Nubs\RandomNameGenerator\Vgng()
+    ]
+);
 ```
 
 ### Video Game Names

--- a/src/All.php
+++ b/src/All.php
@@ -15,16 +15,28 @@ class All implements Generator
     protected $_randomizer;
 
     /**
-     * Initializes the All Generator with the default generator list.
+     * Initializes the All Generator with the list of generators to choose from.
      *
      * @api
      * @param array $generators The random generators to use.
      * @param \Cinam\Randomizer\Randomizer $randomizer The random number generator.
      */
-    public function __construct(array $generators = [], Randomizer $randomizer = null)
+    public function __construct(array $generators, Randomizer $randomizer = null)
     {
-        $this->_generators = empty($generators) ? ['\Nubs\RandomNameGenerator\Alliteration', '\Nubs\RandomNameGenerator\Vgng'] : $generators;
+        $this->_generators = $generators;
         $this->_randomizer = $randomizer;
+    }
+
+    /**
+     * Constructs an All Generator using the default list of generators.
+     *
+     * @api
+     * @param \Cinam\Randomizer\Randomizer $randomizer The random number generator.
+     * @return \Nubs\RandomNameGenerator\All The constructed generator.
+     */
+    public static function create(Randomizer $randomizer = null)
+    {
+        return new self([new Alliteration($randomizer), new Vgng($randomizer)], $randomizer);
     }
 
     /**
@@ -45,10 +57,6 @@ class All implements Generator
      */
     protected function _getRandomGenerator()
     {
-        $generator = $this->_randomizer ?
-            $this->_randomizer->getArrayValue($this->_generators) :
-            $this->_generators[array_rand($this->_generators)];
-
-        return new $generator($this->_randomizer);
+        return $this->_randomizer ? $this->_randomizer->getArrayValue($this->_generators) : $this->_generators[array_rand($this->_generators)];
     }
 }

--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -15,6 +15,7 @@ class AllTest extends PHPUnit_Framework_TestCase
      *
      * @test
      * @covers ::__construct
+     * @covers ::create
      * @covers ::getName
      * @uses \Nubs\RandomNameGenerator\Alliteration
      * @uses \Nubs\RandomNameGenerator\Vgng
@@ -23,7 +24,7 @@ class AllTest extends PHPUnit_Framework_TestCase
      */
     public function getNameBasic()
     {
-        $generator = new All();
+        $generator = All::create();
         $name = $generator->getName();
         $this->assertRegexp('/.+/', $name);
     }
@@ -33,6 +34,7 @@ class AllTest extends PHPUnit_Framework_TestCase
      *
      * @test
      * @covers ::__construct
+     * @covers ::create
      * @covers ::getName
      * @uses \Nubs\RandomNameGenerator\Alliteration
      *
@@ -41,10 +43,10 @@ class AllTest extends PHPUnit_Framework_TestCase
     public function getNameForced()
     {
         $numberGenerator = $this->getMock('\Cinam\Randomizer\NumberGenerator', array('getInt'));
-        $numberGenerator->expects($this->exactly(3))->method('getInt')->will($this->onConsecutiveCalls(0, 20, 5));
+        $numberGenerator->expects($this->exactly(2))->method('getInt')->will($this->onConsecutiveCalls(20, 5));
         $randomizer = new Randomizer($numberGenerator);
 
-        $generator = new All([], $randomizer);
+        $generator = new All([new Alliteration($randomizer)]);
         $this->assertSame('Black Beetle', $generator->getName());
     }
 }


### PR DESCRIPTION
Instead of creating the generator using class names which will be constructed, instead initialize it with the already constructed generators.  This will allow the generators to be configured in ways other than the default configuration.

The previous behavior is still supported using a static `create` method instead.