### PR TITLE
Added __toString() to all classes implementing Generator interface

### DIFF
--- a/src/AbstractGenerator.php
+++ b/src/AbstractGenerator.php
@@ -1,0 +1,19 @@
+<?php
+namespace Nubs\RandomNameGenerator;
+
+abstract class AbstractGenerator implements Generator
+{
+    /**
+     * Alias for getName so that the generator can be directly stringified.
+     *
+     * Note that this will return a different name everytime it is cast to a
+     * string.
+     *
+     * @api
+     * @return string A random name.
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+}

--- a/src/All.php
+++ b/src/All.php
@@ -6,7 +6,7 @@ use Cinam\Randomizer\Randomizer;
 /**
  * A generator that uses all of the other generators randomly.
  */
-class All implements Generator
+class All extends AbstractGenerator implements Generator
 {
     /** @type array The other generators to use. */
     protected $_generators;

--- a/src/Alliteration.php
+++ b/src/Alliteration.php
@@ -6,7 +6,7 @@ use Cinam\Randomizer\Randomizer;
 /**
  * Defines an alliterative name generator.
  */
-class Alliteration implements Generator
+class Alliteration extends AbstractGenerator implements Generator
 {
     /** @type array The definition of the potential adjectives. */
     protected $_adjectives;

--- a/src/Vgng.php
+++ b/src/Vgng.php
@@ -8,7 +8,7 @@ use Cinam\Randomizer\Randomizer;
  * https://github.com/nullpuppy/vgng which in turn is based off of
  * http://videogamena.me/vgng.js.
  */
-class Vgng implements Generator
+class Vgng extends AbstractGenerator implements Generator
 {
     /** @type array The definition of the potential names. */
     protected $_definitionSets;

--- a/tests/AllTest.php
+++ b/tests/AllTest.php
@@ -49,4 +49,24 @@ class AllTest extends PHPUnit_Framework_TestCase
         $generator = new All([new Alliteration($randomizer)]);
         $this->assertSame('Black Bear', $generator->getName());
     }
+
+    /**
+     * Verify basic behavior of __toString().
+     *
+     * @test
+     * @covers ::__construct
+     * @covers ::create
+     * @covers ::__toString
+     * @covers ::getName
+     * @uses \Nubs\RandomNameGenerator\Alliteration
+     * @uses \Nubs\RandomNameGenerator\Vgng
+     *
+     * @return void
+     */
+    public function toStringBasic()
+    {
+        $generator = All::create();
+        $name = (string)$generator;
+        $this->assertRegexp('/.+/', $name);
+    }
 }

--- a/tests/AlliterationTest.php
+++ b/tests/AlliterationTest.php
@@ -45,4 +45,22 @@ class AlliterationTest extends PHPUnit_Framework_TestCase
         $generator = new Alliteration($randomizer);
         $this->assertSame('Black Bear', $generator->getName());
     }
+
+    /**
+     * Verify basic behavior of __toString().
+     *
+     * @test
+     * @covers ::__construct
+     * @covers ::__toString
+     * @covers ::getName
+     *
+     * @return void
+     */
+    public function toStringBasic()
+    {
+        $generator = new Alliteration();
+        $parts = explode(' ', (string)$generator);
+        $this->assertSame(2, count($parts));
+        $this->assertSame($parts[0][0], $parts[1][0]);
+    }
 }

--- a/tests/VgngTest.php
+++ b/tests/VgngTest.php
@@ -45,4 +45,23 @@ class VgngTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame('3D Aerobics Academy', $vgng->getName());
     }
+
+    /**
+     * Verify that toString returns the expected name.
+     *
+     * @test
+     * @covers ::__construct
+     * @covers ::__toString
+     * @covers ::getName
+     */
+    public function toStringBasic()
+    {
+        $numberGenerator = $this->createMock('\Cinam\Randomizer\NumberGenerator');
+        $numberGenerator->expects($this->exactly(3))->method('getInt')->will($this->returnValue(1));
+        $randomizer = new Randomizer($numberGenerator);
+
+        $vgng = new Vgng($randomizer);
+
+        $this->assertSame('8-Bit Acid - 3rd Strike', (string)$vgng);
+    }
 }


### PR DESCRIPTION
It seems a bit redundant to call getName() when the only purpose of this package is to return a string. 

```
// this will return the generated name string.
echo \Nubs\RandomNameGenerator\Alliteration();

echo new \Nubs\RandomNameGenerator\Vgng();

echo \Nubs\RandomNameGenerator\All::create();
```

