### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 php:
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 install: composer install
 script: ./vendor/bin/phpunit --coverage-clover clover.xml

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php": "~5.6 || ~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "satooshi/php-coveralls": "~1.0",
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0",
+        "php-coveralls/php-coveralls": "~1.0",
         "cinam/randomizer": ">=1.1.1,<2.0",
         "squizlabs/php_codesniffer": "~2.3"
     },

--- a/tests/AlliterationTest.php
+++ b/tests/AlliterationTest.php
@@ -1,14 +1,15 @@
 <?php
 namespace Nubs\RandomNameGenerator;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Cinam\Randomizer\Randomizer;
+use Cinam\Randomizer\NumberGenerator;
 
 /**
  * @coversDefaultClass \Nubs\RandomNameGenerator\Alliteration
  * @covers ::<protected>
  */
-class AlliterationTest extends PHPUnit_Framework_TestCase
+class AlliterationTest extends TestCase
 {
     /**
      * Verify basic behavior of getName().
@@ -23,7 +24,7 @@ class AlliterationTest extends PHPUnit_Framework_TestCase
     {
         $generator = new Alliteration();
         $parts = explode(' ', $generator->getName());
-        $this->assertSame(2, count($parts));
+        $this->assertCount(2, $parts);
         $this->assertSame($parts[0][0], $parts[1][0]);
     }
 
@@ -38,7 +39,7 @@ class AlliterationTest extends PHPUnit_Framework_TestCase
      */
     public function getNameForced()
     {
-        $numberGenerator = $this->createMock('\Cinam\Randomizer\NumberGenerator');
+        $numberGenerator = $this->createMock(NumberGenerator::class);
         $numberGenerator->expects($this->exactly(2))->method('getInt')->will($this->onConsecutiveCalls(20, 5));
         $randomizer = new Randomizer($numberGenerator);
 
@@ -60,7 +61,7 @@ class AlliterationTest extends PHPUnit_Framework_TestCase
     {
         $generator = new Alliteration();
         $parts = explode(' ', (string)$generator);
-        $this->assertSame(2, count($parts));
+        $this->assertCount(2, $parts);
         $this->assertSame($parts[0][0], $parts[1][0]);
     }
 }


### PR DESCRIPTION
# Changed log

- Using the class-based PHPUnit namespace to be compatible with latest stable PHPUnit version.
- Using the `php-coveralls/php-coveralls` because the original `php-coversll` is abandoned.
- Using the `assertCount` to assert the actual array result length is same as expected length. 